### PR TITLE
fix: allowed convertable (structs) fields to be converted

### DIFF
--- a/examples/basic/config.go
+++ b/examples/basic/config.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/ls6-events/confuse"
+import (
+	"github.com/ls6-events/confuse"
+	"time"
+)
 
 type Config struct {
 	Foo            string `validate:"required"`
@@ -14,6 +17,8 @@ type Config struct {
 	DiffName DiffName `config:"different_name"`
 
 	PointerStruct *PointerStruct
+
+	Date time.Time
 }
 
 type DatabaseConfig struct {

--- a/examples/basic/config.yaml
+++ b/examples/basic/config.yaml
@@ -12,3 +12,4 @@ different_name:
   hello: world
 pointer_struct:
   hello: world
+date: 2019-01-01

--- a/examples/basic/config_test.go
+++ b/examples/basic/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 )
 
 func TestConfig(t *testing.T) {
@@ -26,4 +27,6 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, "world", config.DiffName.Hello)
 
 	require.Equal(t, "world", config.PointerStruct.Hello)
+
+	require.Equal(t, "2019-01-01T00:00:00Z", config.Date.Format(time.RFC3339))
 }

--- a/unmarshal_map_to_struct.go
+++ b/unmarshal_map_to_struct.go
@@ -60,6 +60,13 @@ func parseMapToStruct(parent any, m map[string]any) error {
 }
 
 func parseField(field reflect.Value, m map[string]any, key string, value any) error {
+	// If the value can be converted initially to the type of the field, then we can set it.
+	if reflect.TypeOf(value).ConvertibleTo(field.Type()) {
+		field.Set(reflect.ValueOf(value).Convert(field.Type()))
+		return nil
+	}
+
+	// Otherwise we need to parse the value.
 	switch field.Kind() {
 	case reflect.Ptr:
 		if field.IsNil() {

--- a/unmarshal_map_to_struct_test.go
+++ b/unmarshal_map_to_struct_test.go
@@ -3,6 +3,7 @@ package confuse
 import (
 	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 )
 
 func TestParseMapToStruct(t *testing.T) {
@@ -241,5 +242,32 @@ func TestParseMapToStruct(t *testing.T) {
 		require.Equal(t, 42, s.World)
 		require.Equal(t, true, s.Test)
 		require.Equal(t, 42.42, s.Float)
+	})
+
+	t.Run("should be able to parse a field if it is an exact match type (e.g. time.Time)", func(t *testing.T) {
+		var s struct {
+			Hello string
+			World int
+			Test  bool
+			Float float64
+			Time  time.Time
+		}
+
+		m := map[string]any{
+			"Hello": "Hello",
+			"World": 42,
+			"Test":  true,
+			"Float": 42.42,
+			"Time":  time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+
+		err := parseMapToStruct(&s, m)
+		require.NoError(t, err)
+
+		require.Equal(t, "Hello", s.Hello)
+		require.Equal(t, 42, s.World)
+		require.Equal(t, true, s.Test)
+		require.Equal(t, 42.42, s.Float)
+		require.Equal(t, time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC), s.Time)
 	})
 }


### PR DESCRIPTION
This allows conversion to/from `time.Time` / any other supported fields by the `yaml` parsing or anything similar. If the field is convertible, we shall convert it initially.